### PR TITLE
Fix index route in readme and spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ submission, view the puppy's information on a show page.
 
    - Use RESTful routing conventions with `resources :puppies`
    - This will create all the standard RESTful routes including:
-     - GET `/` → `puppies#index` (homepage)
+     - GET `/puppies` → `puppies#index` (homepage)
      - GET `/puppies/new` → `puppies#new` (form page)
      - POST `/puppies` → `puppies#create` (process form)
      - GET `/puppies/:id` → `puppies#show` (display puppy)

--- a/spec/rails_forms_lab_spec.rb
+++ b/spec/rails_forms_lab_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
 RSpec.describe "Rails Forms Lab", type: :feature do
-  describe "GET /" do
+  describe "GET /puppies" do
     it "sends a 200 status code" do
-      visit "/"
+      visit "/puppies"
       expect(page.status_code).to eq(200)
     end
 
     it "renders welcome" do
-      visit "/"
+      visit "/puppies"
       expect(page).to have_link("Click Here To List A Puppy")
     end
   end


### PR DESCRIPTION
This pull request updates the application to use the correct RESTful route for the puppies index page, changing references from the root path `/` to `/puppies`. The main changes include updates to documentation and tests to reflect this route change.

**Documentation update:**

* Updated the `README.md` to list `GET /puppies` as the route for the puppies index page instead of `GET /`.

**Test update:**

* Updated the feature spec in `spec/rails_forms_lab_spec.rb` to use `/puppies` instead of `/` for visiting and testing the puppies index page.